### PR TITLE
gitignore and Rserve port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ bin
 
 .tools/
 vendor/
+
+# Ignore environment files
+.env
+.env.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,6 @@ services:
     image: veupathdb/rserve:${RSERVE_TAG:-latest}
     networks:
     - internal
-    environment:
-      RSERVE_PORT: ${RSERVE_PORT:-8081}
     labels:
     - "com.centurylinklabs.watchtower.enable=${RSERVE_WATCHTOWER:-false}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     environment:
       SUBSETTING_SERVICE_URL: ${SUBSETTING_SERVICE_URL:-http://subsetting:8080}
       STREAM_PROCESSING_SERVICE_URL: ${STREAM_PROCESSING_SERVICE_URL:-http://processing}
-      RSERVE_URL: ${RSERVE_URL:-http://rserve}
+      RSERVE_URL: ${RSERVE_URL:-http://rserve:8080}
     labels:
     - "com.centurylinklabs.watchtower.enable=${DATA_WATCHTOWER:-false}"
     - "traefik.http.services.${TRAEFIK_DATA_ROUTER:-edadata-dev}.loadbalancer.server.port=8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     environment:
       SUBSETTING_SERVICE_URL: ${SUBSETTING_SERVICE_URL:-http://subsetting:8080}
       STREAM_PROCESSING_SERVICE_URL: ${STREAM_PROCESSING_SERVICE_URL:-http://processing}
-      RSERVE_URL: ${RSERVE_URL:-http://rserve:8080}
+      RSERVE_URL: ${RSERVE_URL:-http://rserve:6311}
     labels:
     - "com.centurylinklabs.watchtower.enable=${DATA_WATCHTOWER:-false}"
     - "traefik.http.services.${TRAEFIK_DATA_ROUTER:-edadata-dev}.loadbalancer.server.port=8080"


### PR DESCRIPTION
This seems to make the EDA data service functional.

I'm not sure if RSERVE_PORT in the docker-compose.yml has any effect, because the Rserve [Dockerfile seems to have 8080 hardcoded](https://github.com/VEuPathDB/Rserve/blob/main/Dockerfile#L29)

