### PR TITLE
Schema changes for new histogram endpoint

### DIFF
--- a/schema/library.raml
+++ b/schema/library.raml
@@ -7,6 +7,106 @@
 ################################################################################
 
 types:
+  VariableSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      entityId: string
+      variableId: string
+  DerivationType:
+    type: string
+    enum:
+      - transform
+      - reduction
+  DerivedVariable:
+    type: VariableSpec
+    properties:
+      variableType: API_VariableType
+      variableDataShape: API_VariableDataShape
+      derivationType: DerivationType
+      functionName: string
+      inputVars: VariableSpec[]
+      config: object # TBD
+  MergedEntityTabularPostRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      studyId: string
+      filters: API_Filter[]
+      entityId: string
+      outputVariables: VariableSpec[]
+      derivedVariables: DerivedVariable[]
+  EntityCountPostRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      filters: API_Filter[]
+  EntityCountPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      count: integer
+  EntityTabularPostRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      filters: API_Filter[]
+      outputVariableIds: string[]
+  EntityTabularPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      counts: string[][]
+  BinUnits:
+    type: string
+    enum:
+      - day
+      - week
+      - month
+      - year
+  BinSpec:
+    type: object
+    additionalProperties: false
+    properties:
+      displayRangeMin: any
+      displayRangeMax: any
+      binWidth?: number
+      binUnits?: BinUnits
+  VariableDistributionPostRequest:
+    type: object
+    additionalProperties: false
+    properties:
+      filters: API_Filter[]
+      binSpec?: BinSpec
+      valueSpec:
+        type: string
+        enum:
+          - count
+          - proportion
+  HistogramBin:
+    type: object
+    additionalProperties: false
+    properties:
+      value: number
+      binStart: string
+      binEnd: string
+      binLabel: string
+  HistogramStats:
+    type: object
+    additionalProperties: false
+    properties:
+      subsetMin?: any
+      subsetMax?: any
+      subsetMean?: any
+      numVarValues: integer
+      numDistinctEntityRecords: integer
+      numMissingCases: integer
+  VariableDistributionPostResponse:
+    type: object
+    additionalProperties: false
+    properties:
+      histogram: HistogramBin[]
+      statistics: HistogramStats
   StudiesGetResponse:
     type: object
     additionalProperties: false
@@ -176,70 +276,4 @@ types:
     properties:
       left: number
       right: number
-  VariableSpec:
-    type: object
-    additionalProperties: false
-    properties:
-      entityId: string
-      variableId: string
-  DerivationType:
-    type: string
-    enum:
-      - transform
-      - reduction
-  DerivedVariable:
-    type: VariableSpec
-    properties:
-      variableType: API_VariableType
-      variableDataShape: API_VariableDataShape
-      derivationType: DerivationType
-      functionName: string
-      inputVars: VariableSpec[]
-      config: object # TBD
-  MergedEntityTabularPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      studyId: string
-      filters: API_Filter[]
-      entityId: string
-      outputVariables: VariableSpec[]
-      derivedVariables: DerivedVariable[]
-  EntityCountPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-  EntityCountPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      count: integer
-  VariableDistributionPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-  VariableDistributionPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      entitiesCount:
-        type: integer
-        minimum: 0
-      distribution:
-        type: object
-        properties:
-          //: integer
-  EntityTabularPostRequest:
-    type: object
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-      outputVariableIds: string[]
-  EntityTabularPostResponse:
-    type: object
-    additionalProperties: false
-    properties:
-      counts: string[][]
 

--- a/schema/url/query.raml
+++ b/schema/url/query.raml
@@ -12,22 +12,6 @@ types:
     properties:
       count: integer
 
-  VariableDistributionPostRequest:
-    additionalProperties: false
-    properties:
-      filters: API_Filter[]
-
-  VariableDistributionPostResponse:
-    additionalProperties: false
-    properties:
-      entitiesCount:
-        type: integer
-        minimum: 0
-      distribution:
-        type: object
-        properties:
-          //: integer
-
   EntityTabularPostRequest:
     additionalProperties: false
     properties:
@@ -38,3 +22,49 @@ types:
     additionalProperties: false
     properties:
       counts: string[][]
+
+  BinUnits:
+    type: string
+    enum: ['day','week','month','year']
+
+  BinSpec:
+    additionalProperties: false
+    properties:
+      displayRangeMin: any  # number | string
+      displayRangeMax: any  # number | string
+      binWidth?: number     # for numeric vars
+      binUnits?: BinUnits   # for date vars
+
+  VariableDistributionPostRequest:
+    additionalProperties: false
+    properties:
+      filters: API_Filter[]
+      binSpec?: BinSpec
+      valueSpec:
+        type: string
+        enum: ['count', 'proportion']
+
+  HistogramBin:
+    additionalProperties: false
+    properties:
+      value: number
+      binStart: string
+      binEnd: string
+      binLabel: string
+
+  HistogramStats:
+    additionalProperties: false
+    properties:
+      subsetMin?: any # number | string
+      subsetMax?: any # number | string
+      subsetMean?: any # number | string
+      numVarValues: integer
+      numDistinctEntityRecords: integer
+      numMissingCases: integer
+      #multiValueDistribution?: integer[] # TODO: add later
+
+  VariableDistributionPostResponse:
+    additionalProperties: false
+    properties:
+      histogram: HistogramBin[]
+      statistics: HistogramStats

--- a/src/main/java/org/veupathdb/service/eda/generated/model/BinSpec.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/BinSpec.java
@@ -1,0 +1,33 @@
+package org.veupathdb.service.eda.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(
+    as = BinSpecImpl.class
+)
+public interface BinSpec {
+  @JsonProperty("displayRangeMin")
+  Object getDisplayRangeMin();
+
+  @JsonProperty("displayRangeMin")
+  void setDisplayRangeMin(Object displayRangeMin);
+
+  @JsonProperty("displayRangeMax")
+  Object getDisplayRangeMax();
+
+  @JsonProperty("displayRangeMax")
+  void setDisplayRangeMax(Object displayRangeMax);
+
+  @JsonProperty("binWidth")
+  Number getBinWidth();
+
+  @JsonProperty("binWidth")
+  void setBinWidth(Number binWidth);
+
+  @JsonProperty("binUnits")
+  BinUnits getBinUnits();
+
+  @JsonProperty("binUnits")
+  void setBinUnits(BinUnits binUnits);
+}

--- a/src/main/java/org/veupathdb/service/eda/generated/model/BinSpecImpl.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/BinSpecImpl.java
@@ -1,0 +1,66 @@
+package org.veupathdb.service.eda.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "displayRangeMin",
+    "displayRangeMax",
+    "binWidth",
+    "binUnits"
+})
+public class BinSpecImpl implements BinSpec {
+  @JsonProperty("displayRangeMin")
+  private Object displayRangeMin;
+
+  @JsonProperty("displayRangeMax")
+  private Object displayRangeMax;
+
+  @JsonProperty("binWidth")
+  private Number binWidth;
+
+  @JsonProperty("binUnits")
+  private BinUnits binUnits;
+
+  @JsonProperty("displayRangeMin")
+  public Object getDisplayRangeMin() {
+    return this.displayRangeMin;
+  }
+
+  @JsonProperty("displayRangeMin")
+  public void setDisplayRangeMin(Object displayRangeMin) {
+    this.displayRangeMin = displayRangeMin;
+  }
+
+  @JsonProperty("displayRangeMax")
+  public Object getDisplayRangeMax() {
+    return this.displayRangeMax;
+  }
+
+  @JsonProperty("displayRangeMax")
+  public void setDisplayRangeMax(Object displayRangeMax) {
+    this.displayRangeMax = displayRangeMax;
+  }
+
+  @JsonProperty("binWidth")
+  public Number getBinWidth() {
+    return this.binWidth;
+  }
+
+  @JsonProperty("binWidth")
+  public void setBinWidth(Number binWidth) {
+    this.binWidth = binWidth;
+  }
+
+  @JsonProperty("binUnits")
+  public BinUnits getBinUnits() {
+    return this.binUnits;
+  }
+
+  @JsonProperty("binUnits")
+  public void setBinUnits(BinUnits binUnits) {
+    this.binUnits = binUnits;
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/generated/model/BinUnits.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/BinUnits.java
@@ -1,0 +1,25 @@
+package org.veupathdb.service.eda.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum BinUnits {
+  @JsonProperty("day")
+  DAY("day"),
+
+  @JsonProperty("week")
+  WEEK("week"),
+
+  @JsonProperty("month")
+  MONTH("month"),
+
+  @JsonProperty("year")
+  YEAR("year");
+
+  private String name;
+
+  BinUnits(String name) {
+    this.name = name;
+  }
+  public String getValue(){ return name; } 
+}
+

--- a/src/main/java/org/veupathdb/service/eda/generated/model/HistogramBin.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/HistogramBin.java
@@ -1,0 +1,33 @@
+package org.veupathdb.service.eda.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(
+    as = HistogramBinImpl.class
+)
+public interface HistogramBin {
+  @JsonProperty("value")
+  Number getValue();
+
+  @JsonProperty("value")
+  void setValue(Number value);
+
+  @JsonProperty("binStart")
+  String getBinStart();
+
+  @JsonProperty("binStart")
+  void setBinStart(String binStart);
+
+  @JsonProperty("binEnd")
+  String getBinEnd();
+
+  @JsonProperty("binEnd")
+  void setBinEnd(String binEnd);
+
+  @JsonProperty("binLabel")
+  String getBinLabel();
+
+  @JsonProperty("binLabel")
+  void setBinLabel(String binLabel);
+}

--- a/src/main/java/org/veupathdb/service/eda/generated/model/HistogramBinImpl.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/HistogramBinImpl.java
@@ -1,0 +1,66 @@
+package org.veupathdb.service.eda.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "value",
+    "binStart",
+    "binEnd",
+    "binLabel"
+})
+public class HistogramBinImpl implements HistogramBin {
+  @JsonProperty("value")
+  private Number value;
+
+  @JsonProperty("binStart")
+  private String binStart;
+
+  @JsonProperty("binEnd")
+  private String binEnd;
+
+  @JsonProperty("binLabel")
+  private String binLabel;
+
+  @JsonProperty("value")
+  public Number getValue() {
+    return this.value;
+  }
+
+  @JsonProperty("value")
+  public void setValue(Number value) {
+    this.value = value;
+  }
+
+  @JsonProperty("binStart")
+  public String getBinStart() {
+    return this.binStart;
+  }
+
+  @JsonProperty("binStart")
+  public void setBinStart(String binStart) {
+    this.binStart = binStart;
+  }
+
+  @JsonProperty("binEnd")
+  public String getBinEnd() {
+    return this.binEnd;
+  }
+
+  @JsonProperty("binEnd")
+  public void setBinEnd(String binEnd) {
+    this.binEnd = binEnd;
+  }
+
+  @JsonProperty("binLabel")
+  public String getBinLabel() {
+    return this.binLabel;
+  }
+
+  @JsonProperty("binLabel")
+  public void setBinLabel(String binLabel) {
+    this.binLabel = binLabel;
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/generated/model/HistogramStats.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/HistogramStats.java
@@ -1,0 +1,45 @@
+package org.veupathdb.service.eda.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(
+    as = HistogramStatsImpl.class
+)
+public interface HistogramStats {
+  @JsonProperty("subsetMin")
+  Object getSubsetMin();
+
+  @JsonProperty("subsetMin")
+  void setSubsetMin(Object subsetMin);
+
+  @JsonProperty("subsetMax")
+  Object getSubsetMax();
+
+  @JsonProperty("subsetMax")
+  void setSubsetMax(Object subsetMax);
+
+  @JsonProperty("subsetMean")
+  Object getSubsetMean();
+
+  @JsonProperty("subsetMean")
+  void setSubsetMean(Object subsetMean);
+
+  @JsonProperty("numVarValues")
+  int getNumVarValues();
+
+  @JsonProperty("numVarValues")
+  void setNumVarValues(int numVarValues);
+
+  @JsonProperty("numDistinctEntityRecords")
+  int getNumDistinctEntityRecords();
+
+  @JsonProperty("numDistinctEntityRecords")
+  void setNumDistinctEntityRecords(int numDistinctEntityRecords);
+
+  @JsonProperty("numMissingCases")
+  int getNumMissingCases();
+
+  @JsonProperty("numMissingCases")
+  void setNumMissingCases(int numMissingCases);
+}

--- a/src/main/java/org/veupathdb/service/eda/generated/model/HistogramStatsImpl.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/HistogramStatsImpl.java
@@ -1,0 +1,94 @@
+package org.veupathdb.service.eda.generated.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "subsetMin",
+    "subsetMax",
+    "subsetMean",
+    "numVarValues",
+    "numDistinctEntityRecords",
+    "numMissingCases"
+})
+public class HistogramStatsImpl implements HistogramStats {
+  @JsonProperty("subsetMin")
+  private Object subsetMin;
+
+  @JsonProperty("subsetMax")
+  private Object subsetMax;
+
+  @JsonProperty("subsetMean")
+  private Object subsetMean;
+
+  @JsonProperty("numVarValues")
+  private int numVarValues;
+
+  @JsonProperty("numDistinctEntityRecords")
+  private int numDistinctEntityRecords;
+
+  @JsonProperty("numMissingCases")
+  private int numMissingCases;
+
+  @JsonProperty("subsetMin")
+  public Object getSubsetMin() {
+    return this.subsetMin;
+  }
+
+  @JsonProperty("subsetMin")
+  public void setSubsetMin(Object subsetMin) {
+    this.subsetMin = subsetMin;
+  }
+
+  @JsonProperty("subsetMax")
+  public Object getSubsetMax() {
+    return this.subsetMax;
+  }
+
+  @JsonProperty("subsetMax")
+  public void setSubsetMax(Object subsetMax) {
+    this.subsetMax = subsetMax;
+  }
+
+  @JsonProperty("subsetMean")
+  public Object getSubsetMean() {
+    return this.subsetMean;
+  }
+
+  @JsonProperty("subsetMean")
+  public void setSubsetMean(Object subsetMean) {
+    this.subsetMean = subsetMean;
+  }
+
+  @JsonProperty("numVarValues")
+  public int getNumVarValues() {
+    return this.numVarValues;
+  }
+
+  @JsonProperty("numVarValues")
+  public void setNumVarValues(int numVarValues) {
+    this.numVarValues = numVarValues;
+  }
+
+  @JsonProperty("numDistinctEntityRecords")
+  public int getNumDistinctEntityRecords() {
+    return this.numDistinctEntityRecords;
+  }
+
+  @JsonProperty("numDistinctEntityRecords")
+  public void setNumDistinctEntityRecords(int numDistinctEntityRecords) {
+    this.numDistinctEntityRecords = numDistinctEntityRecords;
+  }
+
+  @JsonProperty("numMissingCases")
+  public int getNumMissingCases() {
+    return this.numMissingCases;
+  }
+
+  @JsonProperty("numMissingCases")
+  public void setNumMissingCases(int numMissingCases) {
+    this.numMissingCases = numMissingCases;
+  }
+}

--- a/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostRequest.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostRequest.java
@@ -13,4 +13,32 @@ public interface VariableDistributionPostRequest {
 
   @JsonProperty("filters")
   void setFilters(List<APIFilter> filters);
+
+  @JsonProperty("binSpec")
+  BinSpec getBinSpec();
+
+  @JsonProperty("binSpec")
+  void setBinSpec(BinSpec binSpec);
+
+  @JsonProperty("valueSpec")
+  ValueSpecType getValueSpec();
+
+  @JsonProperty("valueSpec")
+  void setValueSpec(ValueSpecType valueSpec);
+
+  enum ValueSpecType {
+    @JsonProperty("count")
+    COUNT("count"),
+
+    @JsonProperty("proportion")
+    PROPORTION("proportion");
+
+    private String name;
+
+    ValueSpecType(String name) {
+      this.name = name;
+    }
+    public String getValue(){ return name; } 
 }
+}
+

--- a/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostRequestImpl.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostRequestImpl.java
@@ -6,10 +6,20 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder("filters")
+@JsonPropertyOrder({
+    "filters",
+    "binSpec",
+    "valueSpec"
+})
 public class VariableDistributionPostRequestImpl implements VariableDistributionPostRequest {
   @JsonProperty("filters")
   private List<APIFilter> filters;
+
+  @JsonProperty("binSpec")
+  private BinSpec binSpec;
+
+  @JsonProperty("valueSpec")
+  private VariableDistributionPostRequest.ValueSpecType valueSpec;
 
   @JsonProperty("filters")
   public List<APIFilter> getFilters() {
@@ -19,5 +29,25 @@ public class VariableDistributionPostRequestImpl implements VariableDistribution
   @JsonProperty("filters")
   public void setFilters(List<APIFilter> filters) {
     this.filters = filters;
+  }
+
+  @JsonProperty("binSpec")
+  public BinSpec getBinSpec() {
+    return this.binSpec;
+  }
+
+  @JsonProperty("binSpec")
+  public void setBinSpec(BinSpec binSpec) {
+    this.binSpec = binSpec;
+  }
+
+  @JsonProperty("valueSpec")
+  public VariableDistributionPostRequest.ValueSpecType getValueSpec() {
+    return this.valueSpec;
+  }
+
+  @JsonProperty("valueSpec")
+  public void setValueSpec(VariableDistributionPostRequest.ValueSpecType valueSpec) {
+    this.valueSpec = valueSpec;
   }
 }

--- a/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostResponse.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostResponse.java
@@ -1,35 +1,22 @@
 package org.veupathdb.service.eda.generated.model;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import java.util.Map;
+import java.util.List;
 
 @JsonDeserialize(
     as = VariableDistributionPostResponseImpl.class
 )
 public interface VariableDistributionPostResponse {
-  @JsonProperty("entitiesCount")
-  int getEntitiesCount();
+  @JsonProperty("histogram")
+  List<HistogramBin> getHistogram();
 
-  @JsonProperty("entitiesCount")
-  void setEntitiesCount(int entitiesCount);
+  @JsonProperty("histogram")
+  void setHistogram(List<HistogramBin> histogram);
 
-  @JsonProperty("distribution")
-  DistributionType getDistribution();
+  @JsonProperty("statistics")
+  HistogramStats getStatistics();
 
-  @JsonProperty("distribution")
-  void setDistribution(DistributionType distribution);
-
-  @JsonDeserialize(
-      as = VariableDistributionPostResponseImpl.DistributionTypeImpl.class
-  )
-  interface DistributionType {
-    @JsonAnyGetter
-    Map<String, Object> getAdditionalProperties();
-
-    @JsonAnySetter
-    void setAdditionalProperties(String key, Object value);
-  }
+  @JsonProperty("statistics")
+  void setStatistics(HistogramStats statistics);
 }

--- a/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostResponseImpl.java
+++ b/src/main/java/org/veupathdb/service/eda/generated/model/VariableDistributionPostResponseImpl.java
@@ -1,59 +1,39 @@
 package org.veupathdb.service.eda.generated.model;
 
-import com.fasterxml.jackson.annotation.JsonAnyGetter;
-import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.util.Map;
+import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "entitiesCount",
-    "distribution"
+    "histogram",
+    "statistics"
 })
 public class VariableDistributionPostResponseImpl implements VariableDistributionPostResponse {
-  @JsonProperty("entitiesCount")
-  private int entitiesCount;
+  @JsonProperty("histogram")
+  private List<HistogramBin> histogram;
 
-  @JsonProperty("distribution")
-  private VariableDistributionPostResponse.DistributionType distribution;
+  @JsonProperty("statistics")
+  private HistogramStats statistics;
 
-  @JsonProperty("entitiesCount")
-  public int getEntitiesCount() {
-    return this.entitiesCount;
+  @JsonProperty("histogram")
+  public List<HistogramBin> getHistogram() {
+    return this.histogram;
   }
 
-  @JsonProperty("entitiesCount")
-  public void setEntitiesCount(int entitiesCount) {
-    this.entitiesCount = entitiesCount;
+  @JsonProperty("histogram")
+  public void setHistogram(List<HistogramBin> histogram) {
+    this.histogram = histogram;
   }
 
-  @JsonProperty("distribution")
-  public VariableDistributionPostResponse.DistributionType getDistribution() {
-    return this.distribution;
+  @JsonProperty("statistics")
+  public HistogramStats getStatistics() {
+    return this.statistics;
   }
 
-  @JsonProperty("distribution")
-  public void setDistribution(VariableDistributionPostResponse.DistributionType distribution) {
-    this.distribution = distribution;
-  }
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  @JsonPropertyOrder
-  public static class DistributionTypeImpl implements VariableDistributionPostResponse.DistributionType {
-    @JsonIgnore
-    private Map<String, Object> additionalProperties = new ExcludingMap();
-
-    @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
-      return additionalProperties;
-    }
-
-    @JsonAnySetter
-    public void setAdditionalProperties(String key, Object value) {
-      this.additionalProperties.put(key, value);
-    }
+  @JsonProperty("statistics")
+  public void setStatistics(HistogramStats statistics) {
+    this.statistics = statistics;
   }
 }


### PR DESCRIPTION
Sorry- this is where the actual API changes are.  In query.raml.  Danielle, maybe we want to consider merging the APIs of the new and old histograms (thinking bin specs, etc.)?  I need to replace some of the dataService-specific schema with common schema still that I copied from there.