### PR TITLE
add helpers for grabbing variables and ancestors

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/common/model/ReferenceMetadata.java
+++ b/src/main/java/org/veupathdb/service/eda/common/model/ReferenceMetadata.java
@@ -9,8 +9,11 @@ import org.gusdb.fgputil.validation.ValidationException;
 import org.gusdb.fgputil.validation.ValidationLevel;
 import org.veupathdb.service.eda.generated.model.*;
 
+import com.google.common.base.Predicate;
+
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Encapsulates EDA study metadata for a single study, to be used by various services.  This includes native, computed,
@@ -356,6 +359,23 @@ public class ReferenceMetadata {
             .map(entity -> entity.getIdColumnDef().getVariableId())
             .collect(Collectors.toList()))
         .toList();
+  }
+
+  /**
+   * Given a stream of entities, returns all variables based on a predicate (ex. keep only continuous variables)
+   * Does not return id variables.
+   * 
+   * @param entities entities whose variables should be evaluated and returned
+   * @param predicate predicate used to filter variables. ID variables are always removed.
+   * @return list of variables on ancestor entities
+   */
+  public List<VariableDef> getVariablesByPredicate(Stream<EntityDef> entities, Predicate<VariableDef> predicate) {
+    return entities
+        .flatMap(entityDef -> entityDef.getVariables().stream()) // Flatten stream of var streams into a single stream of vars.
+        .filter(var -> var.getSource().isResident()) // Filter out inherited variables.
+        .filter(var -> predicate.test(var)) // Filter out variables based on predicate.
+        .filter(var -> !var.getVariableId().contains("_stable_id")) // Filter out id variables
+        .collect(Collectors.toList());
   }
 
   private static Optional<List<EntityDef>> getAncestors(EntityDef targetEntity, TreeNode<EntityDef> entityTree, List<EntityDef> ancestors) {

--- a/src/main/java/org/veupathdb/service/eda/common/plugin/util/PluginUtil.java
+++ b/src/main/java/org/veupathdb/service/eda/common/plugin/util/PluginUtil.java
@@ -147,6 +147,14 @@ public class PluginUtil {
 
   }
 
+  public Boolean getManyToOneWithDescendant(ReferenceMetadata metadata, EntityDef ancestor, EntityDef descendantToMatch) {
+    return metadata.getChildren(ancestor).stream()
+        .filter(child -> metadata.isEntityAncestorOf(child, descendantToMatch) || descendantToMatch.getId().equals(child.getId())) // Find child on path to descendant to match.
+        .findFirst()
+        .orElseThrow()
+        .isManyToOneWithParent();
+  }
+
   //deprecated
   public List<VariableDef> getChildrenVariables(VariableSpec collectionVar) {
     EntityDef collectionVarEntityDef = _metadata.getEntity(collectionVar.getEntityId()).orElseThrow();


### PR DESCRIPTION
Discussed here: https://github.com/VEuPathDB/service-eda-compute/pull/74

This PR adds two methods that helps the correlation app (and hopefully future apps!) get its variables and entities more easily.

First we add `getVariablesByPredicate` which returns all variables on the submitted entities, as long as those variables are not id variables and those variables pass the submitted predicate (for correlation the predicate would be is the data shape continuous).

Second, we add `getManyToOneWithDescendent` which tells us if a given entity is one-to-one with a given descendent. This is the opposite thinking of `isOneToOneWithParent`.