### PR TITLE
Add JsonIgnore to vocabulary field in VariableDef

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,7 @@ repositories {
 
 dependencies {
 
+  implementation("org.junit.jupiter:junit-jupiter:5.8.1")
   // versions
   val fgputil = "2.12.9-jakarta" // FgpUtil version
 

--- a/src/main/java/org/veupathdb/service/eda/common/model/VariableDef.java
+++ b/src/main/java/org/veupathdb/service/eda/common/model/VariableDef.java
@@ -73,6 +73,7 @@ public class VariableDef extends VariableSpecImpl {
   @JsonIgnore
   private final VariableSpec _variableSpecToImputeZeroesFor;
 
+  @JsonIgnore
   private final List<String> _vocabulary;
 
   public VariableDef(

--- a/src/main/java/org/veupathdb/service/eda/common/model/VariableDef.java
+++ b/src/main/java/org/veupathdb/service/eda/common/model/VariableDef.java
@@ -160,6 +160,7 @@ public class VariableDef extends VariableSpecImpl {
     return _variableSpecToImputeZeroesFor;
   }
 
+  @JsonIgnore
   public List<String> getVocabulary() {
     return _vocabulary;
   }

--- a/src/test/java/org.veupathdb.service.eda.common/VariableDefTest.java
+++ b/src/test/java/org.veupathdb.service.eda.common/VariableDefTest.java
@@ -1,0 +1,39 @@
+package org.veupathdb.service.eda.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.gusdb.fgputil.json.JsonUtil;
+import org.junit.jupiter.api.Test;
+import org.veupathdb.service.eda.common.model.DataRanges;
+import org.veupathdb.service.eda.common.model.VariableDef;
+import org.veupathdb.service.eda.common.model.VariableSource;
+import org.veupathdb.service.eda.generated.model.APIVariableDataShape;
+import org.veupathdb.service.eda.generated.model.APIVariableType;
+import org.veupathdb.service.eda.generated.model.VariableSpec;
+import org.veupathdb.service.eda.generated.model.VariableSpecImpl;
+
+import java.util.List;
+import java.util.Optional;
+
+public class VariableDefTest {
+
+  @Test
+  public void testSerializeDeserialize() throws JsonProcessingException {
+    VariableDef variableDef = new VariableDef(
+        "entityId",
+        "variableId",
+        APIVariableType.INTEGER,
+        APIVariableDataShape.CONTINUOUS,
+        false,
+        false,
+        Optional.empty(),
+        Optional.empty(),
+        "parentId",
+        List.of("1", "2"),
+        false,
+        null,
+        VariableSource.NATIVE
+    );
+    String serialized = JsonUtil.serializeObject(variableDef);
+    JsonUtil.Jackson.readValue(serialized, VariableSpecImpl.class);
+  }
+}


### PR DESCRIPTION
The use of inheritance of the generated `VariableSpec` class here is a little tricky. But the missing JsonIgnore annotation caused vocabulary to be serialized where `VariableDef` was being used as a `VariableSpec`