### PR TITLE
Fixes to eagerly check if stream is empty when instantiating NonEmptyResultStream

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/common/client/NonEmptyResultStream.java
+++ b/src/main/java/org/veupathdb/service/eda/common/client/NonEmptyResultStream.java
@@ -3,6 +3,8 @@ package org.veupathdb.service.eda.common.client;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Wrapper around an input stream whose content must be a newline-delimited
@@ -24,30 +26,53 @@ public class NonEmptyResultStream extends BufferedInputStream {
   private boolean _foundFirstNewline = false;
   private boolean _continueChecking = true;
 
+  private List<Byte> firstLine;
+
   public NonEmptyResultStream(String streamName, InputStream in) {
     super(in);
+    firstLine = new ArrayList<>();
     _streamName = streamName;
+    while (_continueChecking) {
+      try {
+        int nextByte = in.read();
+        if (nextByte == -1) throwException();
+        byte b = ((Integer) nextByte).byteValue();
+        firstLine.add(b);
+        check(b);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   @Override
   public int read() throws IOException {
-    int nextByte = super.read();
-    if (_continueChecking) {
-      if (nextByte == -1) throwException();
-      byte b = ((Integer)nextByte).byteValue();
-      check(b);
+    if (!firstLine.isEmpty()) {
+      return firstLine.remove(0);
     }
-    return nextByte;
+    return super.read();
   }
 
   @Override
   public synchronized int read(byte[] b, int off, int len) throws IOException {
-    int bytesRead = super.read(b, off, len);
-    if (_continueChecking) {
-      if (bytesRead == -1) throwException();
-      for (int i = 0; i < bytesRead && _continueChecking; i++) {
-        check(b[i]);
+    if (firstLine.isEmpty()) {
+      return super.read(b, off, len);
+    }
+
+    if (len > firstLine.size()) {
+      int i = off;
+      while (!firstLine.isEmpty()) {
+        b[i++] = firstLine.remove(0);
       }
+      int bytesRead = (i - off);
+      return bytesRead + super.read(b, i, len - bytesRead);
+    }
+
+    int i = off;
+    int bytesRead = 0;
+    while (bytesRead < len) {
+      b[i++] = firstLine.remove(0);
+      bytesRead++;
     }
     return bytesRead;
   }

--- a/src/main/java/org/veupathdb/service/eda/common/client/NonEmptyResultStream.java
+++ b/src/main/java/org/veupathdb/service/eda/common/client/NonEmptyResultStream.java
@@ -26,7 +26,7 @@ public class NonEmptyResultStream extends BufferedInputStream {
   private boolean _foundFirstNewline = false;
   private boolean _continueChecking = true;
 
-  private List<Byte> firstLine;
+  private final List<Byte> firstLine;
 
   public NonEmptyResultStream(String streamName, InputStream in) {
     super(in);
@@ -34,7 +34,7 @@ public class NonEmptyResultStream extends BufferedInputStream {
     _streamName = streamName;
     while (_continueChecking) {
       try {
-        int nextByte = in.read();
+        int nextByte = super.read();
         if (nextByte == -1) throwException();
         byte b = ((Integer) nextByte).byteValue();
         firstLine.add(b);

--- a/src/main/java/org/veupathdb/service/eda/common/client/StreamingDataClient.java
+++ b/src/main/java/org/veupathdb/service/eda/common/client/StreamingDataClient.java
@@ -35,9 +35,17 @@ public abstract class StreamingDataClient extends ServiceClient {
       List<StreamSpec> requiredStreams,
       Function<StreamSpec, ResponseFuture> streamGenerator,
       FunctionalInterfaces.ConsumerWithException<Map<String, InputStream>> streamProcessor) {
-    try (AutoCloseableList<InputStream> dataStreams = buildDataStreams(requiredStreams, streamGenerator)) {
+    AutoCloseableList<InputStream> dataStreams = buildDataStreams(requiredStreams, streamGenerator);
+    processDataStreams(requiredStreams, dataStreams, streamProcessor);
+  }
+
+  public static void processDataStreams(
+      List<StreamSpec> requiredStreams,
+      AutoCloseableList<InputStream> dataStreams,
+      FunctionalInterfaces.ConsumerWithException<Map<String, InputStream>> streamProcessor) {
+    try (dataStreams) {
       // convert auto-closeable list into a named stream map for processing
-      Map<String,InputStream> streamMap = new LinkedHashMap<>();
+      Map<String, InputStream> streamMap = new LinkedHashMap<>();
       for (int i = 0; i < dataStreams.size(); i++) {
         streamMap.put(requiredStreams.get(i).getStreamName(), dataStreams.get(i));
       }
@@ -45,9 +53,9 @@ public abstract class StreamingDataClient extends ServiceClient {
     }
   }
 
-  private static AutoCloseableList<InputStream> buildDataStreams(
+  public static AutoCloseableList<InputStream> buildDataStreams(
       List<StreamSpec> requiredStreams,
-      Function<StreamSpec,ResponseFuture> streamGenerator) {
+      Function<StreamSpec, ResponseFuture> streamGenerator) {
     AutoCloseableList<InputStream> dataStreams = new AutoCloseableList<>();
     Map<String, ResponseFuture> responses = new HashMap<>();
     try {
@@ -61,21 +69,30 @@ public abstract class StreamingDataClient extends ServiceClient {
 
       // get results
       for (StreamSpec spec : requiredStreams) {
-        dataStreams.add(responses.get(spec.getStreamName()).getInputStream());
+        dataStreams.add(new NonEmptyResultStream(spec.getStreamName(), responses.get(spec.getStreamName()).getInputStream()));
         responses.remove(spec.getStreamName());
       }
       return dataStreams;
     }
-    catch (Exception e) {
-      // if exception occurs while creating streams; need to clean up (two parts)
-      // 1. cancel remaining responses not opened
-      for (ResponseFuture response : responses.values()) {
-        response.cancel();
-      }
-      // 2. close any that successfully opened
-      dataStreams.close();
-      // throw as a runtime exception
-      throw new RuntimeException("Unable to fetch all required data", e);
+    // Explicitly catch EmptyResult so that it can be re-thrown and caught downstream without being wrapped in generic catch.
+    catch (NonEmptyResultStream.EmptyResultException e) {
+      cleanDataStreams(responses, dataStreams);
+      throw e;
     }
+    catch (Exception e) {
+      cleanDataStreams(responses, dataStreams);
+      // throw as a runtime exception
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void cleanDataStreams(Map<String, ResponseFuture> responses, AutoCloseableList<InputStream> dataStreams) {
+    // if exception occurs while creating streams; need to clean up (two parts)
+    // 1. cancel remaining responses not opened
+    for (ResponseFuture response : responses.values()) {
+      response.cancel();
+    }
+    // 2. close any that successfully opened
+    dataStreams.close();
   }
 }

--- a/src/main/java/org/veupathdb/service/eda/common/client/StreamingDataClient.java
+++ b/src/main/java/org/veupathdb/service/eda/common/client/StreamingDataClient.java
@@ -82,7 +82,7 @@ public abstract class StreamingDataClient extends ServiceClient {
     catch (Exception e) {
       cleanDataStreams(responses, dataStreams);
       // throw as a runtime exception
-      throw new RuntimeException(e);
+      throw new RuntimeException("Unable to fetch all required data", e);
     }
   }
 

--- a/src/test/java/org.veupathdb.service.eda.common/NonEmptyResultStreamTest.java
+++ b/src/test/java/org.veupathdb.service.eda.common/NonEmptyResultStreamTest.java
@@ -1,0 +1,63 @@
+package org.veupathdb.service.eda.common.client;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+public class NonEmptyResultStreamTest {
+
+  @Test
+  public void testNonEmptyReadByteByByte() throws Exception{
+    NonEmptyResultStream streamUnderTest = new NonEmptyResultStream(
+        "test-1", new ByteArrayInputStream("first\nsecond".getBytes(StandardCharsets.UTF_8)));
+    Assertions.assertEquals('f', streamUnderTest.read());
+    Assertions.assertEquals('i', streamUnderTest.read());
+    Assertions.assertEquals('r', streamUnderTest.read());
+    Assertions.assertEquals('s', streamUnderTest.read());
+    Assertions.assertEquals('t', streamUnderTest.read());
+    Assertions.assertEquals('\n', streamUnderTest.read());
+    Assertions.assertEquals('s', streamUnderTest.read());
+    Assertions.assertEquals('e', streamUnderTest.read());
+    Assertions.assertEquals('c', streamUnderTest.read());
+    Assertions.assertEquals('o', streamUnderTest.read());
+    Assertions.assertEquals('n', streamUnderTest.read());
+    Assertions.assertEquals('d', streamUnderTest.read());
+  }
+
+  @Test
+  public void testEmptyOnlyHeaders() {
+    Assertions.assertThrows(NonEmptyResultStream.EmptyResultException.class, () -> new NonEmptyResultStream(
+        "test-2", new ByteArrayInputStream("first".getBytes(StandardCharsets.UTF_8))));
+  }
+
+  @Test
+  public void testEmptyNothingInStream() {
+    Assertions.assertThrows(NonEmptyResultStream.EmptyResultException.class, () -> new NonEmptyResultStream(
+        "test-3", new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8))));
+  }
+
+  @Test
+  public void testNonEmptyReadChunkLargerThanFirstLine() throws Exception {
+    byte[] buffer = new byte[8];
+    NonEmptyResultStream streamUnderTest = new NonEmptyResultStream(
+        "test-1", new ByteArrayInputStream("first\nsecond".getBytes(StandardCharsets.UTF_8)));
+    int bytesRead = streamUnderTest.read(buffer);
+    Assertions.assertEquals(8, bytesRead);
+    Assertions.assertEquals("first\nse", new String(buffer, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  public void testNonEmptyReadChunkSmallerThanFirstLine() throws Exception {
+    byte[] buffer = new byte[3];
+    NonEmptyResultStream streamUnderTest = new NonEmptyResultStream(
+        "test-1", new ByteArrayInputStream("first\nsecond".getBytes(StandardCharsets.UTF_8)));
+    int bytesRead = streamUnderTest.read(buffer);
+    Assertions.assertEquals(3, bytesRead);
+    Assertions.assertEquals("fir", new String(buffer, StandardCharsets.UTF_8));
+    bytesRead = streamUnderTest.read(buffer);
+    Assertions.assertEquals(3, bytesRead);
+    Assertions.assertEquals("st\n", new String(buffer, StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## Overview
* Split construction and processing of streams
* Eagerly check if NonEmptyResultStream is empty

Tested that this request gets a 204:

```
{
    "studyId": "VBP_MEGA",
    "filters": [
        {
            "type": "dateRange",
            "entityId": "OBI_0000659",
            "variableId": "EUPATH_0043256",
            "min": "1928-03-18T00:00:00Z",
            "max": "1956-03-20T00:00:00Z"
        }
    ],
    "config": {
        "geoAggregateVariable": {
            "entityId": "GAZ_00000448",
            "variableId": "EUPATH_0043203"
        },
        "latitudeVariable": {
            "entityId": "GAZ_00000448",
            "variableId": "OBI_0001620"
        },
        "longitudeVariable": {
            "entityId": "GAZ_00000448",
            "variableId": "OBI_0001621"
        },
        "overlayConfig": {
            "overlayType": "categorical",
            "overlayVariable": {
                "variableId": "OBI_0001909",
                "entityId": "EUPATH_0000609"
            },
            "overlayValues": [
                "Aedes vexans",
                "Culex pipiens morphological group",
                "Anopheles <subgenus>",
                "Culex tarsalis",
                "Culex nigripalpus",
                "Anopheles punctipennis",
                "Culex erraticus",
                "__UNSELECTED__"
            ]
        },
        "outputEntityId": "EUPATH_0000609",
        "valueSpec": "count",
        "viewport": {
            "latitude": {
                "xMin": -45.08903556483102,
                "xMax": 77.07878389624943
            },
            "longitude": {
                "left": -170.15624999,
                "right": -170.15625
            }
        }
    }
}
```